### PR TITLE
Use std::shared_ptr instead of inline

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,8 +34,8 @@ class Review {
 private:
 	int id;
 public:
-	Person reviewer;
-	Article article;
+	std::shared_ptr<Person> reviewer;
+	std::shared_ptr<Article> article;
 	Review();
 };
 


### PR DESCRIPTION
Usage of std::shared_ptr is preferred over inline.
Allows for automatic de-allocation on destruction of `Review`